### PR TITLE
sample content dir for local development without dealing with submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ This site is built using [Hugo](https://gohugo.io), a static site generator writ
 
 1. [Install](https://gohugo.io/overview/installing/) Hugo
 1. `$ git clone git@github.com:hackshackers/hackshackers-hugo.git`
-1. `$ cd hackshackers-hugo && git submodule init && git submodule update`
-1. `$ hugo serve`
+1. `$ cd hackshackers-hugo`
+1. To develop locally with _sample_ content (recommended most of the time):
+  1. `$ hugo --config=devConfig.toml server`
+1. To develop locally with _production_ content (Git submodules can be tricky):
+  1. `$ git submodule update --init --recursive`
+  1. `$ hugo server`
 
 That will build the static pages and start the local Go server at [http://localhost:1313/](http://localhost:1313/).
 

--- a/devConfig.toml
+++ b/devConfig.toml
@@ -1,0 +1,12 @@
+# Repeat standard config options
+baseurl = "https://hackshackers.com/"
+enableEmoji = true
+ignoreFiles = [ "README\\.md$" ]
+languageCode = "en-us"
+title = "Hacks/Hackers"
+theme = "hackshackers-2017"
+disableRSS = true
+disableSitemap = true
+
+# Dev-specific config options
+contentDir = "sample-content"

--- a/sample-content/test.md
+++ b/sample-content/test.md
@@ -1,0 +1,16 @@
+{
+  "title": "Test Single Page",
+  "description": "Testing a single page layout with the Hugo theme",
+  "date": "2016-11-21",
+  "tags": ["demo", "test"],
+  "type": "page"
+}
+
+### Just testing
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
Then use `$ hugo --config=devConfig.toml server` to start the local Go server with the `sample-content` directory