### PR TITLE
Direct website contributors to prose, a less technical alternative to github pull request flow

### DIFF
--- a/themes/hackshackers-2017/layouts/partials/utils/suggest-edits.html
+++ b/themes/hackshackers-2017/layouts/partials/utils/suggest-edits.html
@@ -1,4 +1,4 @@
 <a
-  href="https://github.com/hackshackers/hackshackers-hugo-content/edit/master/{{ $.File.Dir }}{{ $.File.LogicalName }}"
+  href="http://prose.io/#hackshackers/hackshackers-hugo-content/edit/master/{{ $.File.Dir }}{{ $.File.LogicalName }}"
   class="link-hack-this"
 >Suggest edits</a>


### PR DESCRIPTION
This tool is created and maintained by Development Seed, the creators of MapBox.

Their is no backend, it just allows the users browser to edit pages via the GitHub API, and magic happens in the browser to let non-GitHub-savvy users suggest edits more easily

This feature request would likely involve:
- [ ] editing template to change link behind "suggest edit" button
- [ ] updating the "hack this site" content

Details: https://github.com/prose/prose/wiki/Getting-Started