### PR TITLE
Quck fix to hide section links in navs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,7 @@ languageCode: "en-us"
 title: "Hacks/Hackers"
 theme: "hackshackers-2017"
 disableKinds: ["RSS", "sitemap"]
+pluralizelisttitles: false
 
 # Dev-specific config options
 # Revert for production use

--- a/themes/hackshackers-2017/layouts/partials/section-list.html
+++ b/themes/hackshackers-2017/layouts/partials/section-list.html
@@ -1,3 +1,5 @@
 {{ range .Subpages }}
+{{ if ne .Path .CurrentSection.Page.Section }}
   <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+{{end}}
 {{ end }}


### PR DESCRIPTION
![Screen Shot 2019-11-14 at 5 58 38 AM](https://user-images.githubusercontent.com/997097/68851390-dd45da80-06a3-11ea-8765-a6ba488ff56c.png)

1. Turns off pluralizing section title (e.g. `_abouts` defaults back to `_about`)
1. Filters those links out of the list of pages in a section

Fwiw, recent versions of Hugo offer better ways of handling this without the weird directory structure and link overrides that we used originally.