### PR TITLE
Fix the suggest edits page

### DIFF
--- a/themes/hackshackers-2017/layouts/partials/utils/suggest-edits.html
+++ b/themes/hackshackers-2017/layouts/partials/utils/suggest-edits.html
@@ -1,4 +1,4 @@
 <a
-  href="https://github.com/hackshackers/hackshackers-hugo-content/edit/master/{{ $.File.Dir }}{{ $.File.LogicalName }}"
+  href="https://github.com/hackshackers/hackshackers-hugo/edit/master/content/{{ $.File.Dir }}{{ $.File.LogicalName }}"
   class="link-hack-this"
 >Suggest edits</a>


### PR DESCRIPTION
The suggest edits button available on various pages on the site was not working. The code had since changed repos, and we needed to update the URL to account for both the new repo URL and a new folder structure in the new repo.

