### PR TITLE
Temporarily deactivate the upcoming events feed

### DIFF
--- a/themes/hackshackers-2017/layouts/index.html
+++ b/themes/hackshackers-2017/layouts/index.html
@@ -4,7 +4,7 @@
 <div class="home-wrapper">
 	{{ partial "map.html" . }}
 	{{ partial "statement.html" (dict "title" .Site.Params.tagline "subtitle" .Site.Params.subtagline) }}
-	{{ partial "home-upcoming-events.html" .Site.Params.events }}
+	{{/* partial "home-upcoming-events.html" .Site.Params.events */}}
 	<div class="home-resource-signup-wrapper">
 		<div class="container">
 			{{ partial "home-resources.html" .Site.Pages }}


### PR DESCRIPTION
While we are working on a fix for the upcoming events feature, we will temporarily deactivate this section from the homepage. This will ensure visitors to the site only see working code. With the completion of this pull request, the homepage will appear as follows:

![image](https://user-images.githubusercontent.com/6817579/112735914-9a4d7580-8f2d-11eb-90d5-a2dd4bf69ab6.png)

The amount of time required to reenable this section is trivial.  