### PR TITLE
280822 twittercard

### DIFF
--- a/content/hh-is-hiring.md
+++ b/content/hh-is-hiring.md
@@ -80,5 +80,4 @@ Position requires familiarity or ability to quickly gain familiarity with issues
 
 Interested applicants should submit their resume, a cover letter explaining their interest and fit, as well as their salary requirements, to jobs [at] hackshackers [dot] com with the subject line “Coordinator - Response.”
 
-<meta name="twitter:card" content="summary">
-<meta name="twitter:image" content="https://www.hackshackers.com/content-images/about/hackshackers_logotype-stacked_small.png" />
+{{< twitter-card >}}

--- a/themes/hackshackers-2017/layouts/partials/utils/og-tags.html
+++ b/themes/hackshackers-2017/layouts/partials/utils/og-tags.html
@@ -13,3 +13,6 @@
 {{ else }}
   <meta property="og:description" content="{{ .Site.Params.og_desc }}" />
 {{ end }}
+<meta name="twitter:card" content="summary">
+<meta property="og:image" content="{{ .Site.Params.og_image.url }}" />
+<meta name="twitter:image" content="{{ .Site.Params.og_image.url  }}" />


### PR DESCRIPTION
Add meta data to be able to include Twitter card in URLs. This edits the page base template, such that once the edit is deployed,  no additional work will be required on any page to be able to include the Twitter meta URL