### PR TITLE
Hide Upcoming Events section 

### DIFF
--- a/themes/hackshackers-2017/layouts/index.html
+++ b/themes/hackshackers-2017/layouts/index.html
@@ -4,7 +4,7 @@
 <div class="home-wrapper">
 	{{ partial "map.html" . }}
 	{{ partial "statement.html" (dict "title" .Site.Params.tagline "subtitle" .Site.Params.subtagline) }}
-	{{ partial "home-upcoming-events.html" .Site.Params.events }}
+	{{/* partial "home-upcoming-events.html" .Site.Params.events */}}
 	<div class="home-resource-signup-wrapper">
 		<div class="container">
 			{{ partial "home-resources.html" .Site.Pages }}


### PR DESCRIPTION
As our upcoming events section is only able to include events from London at the moment (given our current constraints and where the data is hosted), we have decided to hide the upcoming events for the time being. 