### PR TITLE
update to remove reference to Meetup

### DIFF
--- a/content/groups/new-york.md
+++ b/content/groups/new-york.md
@@ -7,7 +7,7 @@ url: groups/new-york
 
 Bringing journalists and technologists together!
 
-Join us on **[Meetup.com](https://www.meetup.com/hacks-hackers-nyc/)**. We also share our events on [Twitter](https://twitter.com/HacksHackersNYC).
+We share our events on [Twitter](https://twitter.com/HacksHackersNYC).
 
 {{< tweet id="1042077500082454529" width=80% >}}
 


### PR DESCRIPTION
In light of the email message that just went out saying that Meetup is no longer being used, removes the reference from the website.