### PR TITLE
Add author bylines

### DIFF
--- a/content/news/2024/01/Prediction-for-Journalism-in-2024-More-open-source-AI.md
+++ b/content/news/2024/01/Prediction-for-Journalism-in-2024-More-open-source-AI.md
@@ -12,8 +12,6 @@ categories:
 
 *We have a chance to try again and learn from the tortured history between technology companies and journalism.*
 
-By Burt Herman, Hacks/Hackers co-founder and board chair.
-
 It is truly magical to speak to a machine using the same language you’d use to talk to a human. And that initial awe at the technology commonly known as generative AI caught a lot of us in the hype over artificial intelligence this past year.
 
 We also learned that while the large language models (LLMs) that power generative AI are great at stringing words together, they have a tendency to BS their way through it. A few media outlets ran into trouble publishing AI-generated words without paying attention to what the words actually said. A promising year also ended with the very human turmoil at OpenAI between the nonprofit board and CEO Sam Altman, raising concerns about governance and control of these powerful tools.

--- a/themes/hackshackers-2017/layouts/_default/single.html
+++ b/themes/hackshackers-2017/layouts/_default/single.html
@@ -12,9 +12,7 @@
       <article>
         <h2 class="single-headline">{{ .Title }}</h2>
 
-
-
-        {{ if eq .Type "blog" }}
+        {{ if eq .Type "news" }}
           {{ partial "meta-single.html" . }}
         {{ else if (isset .Params "sectionfront") }}
           <ul class="section-list">


### PR DESCRIPTION
This pull request will enable author bylines to show up on news (blog) entries. 
For user bios to show up, it will be required for users to continue adding an authors tag in YML language such as the following example, showing a fictional post entry about Coffee health benefits written by "Timothy Author": 

```
---
Title: Coffee shown to have health benefits

Authors: 

- Timothy Author
---
```

FYI: This post also includes a one-time change to remove an Author reference in a case it was added manually.


#186  Completes 